### PR TITLE
Bugfix/SOH-45: Fix Template ordering

### DIFF
--- a/src/selectors/ExercisesSelector.ts
+++ b/src/selectors/ExercisesSelector.ts
@@ -70,7 +70,16 @@ export const getTemplatesSelector: ParametricSelector<LocalStore, string, Workou
 
 function getExercisesForTemplate(template: WorkoutTemplate, exerciseMap: ExerciseMap): Exercise[] {
     const exercises = getExercises('', exerciseMap);
-    return exercises.filter((exercise) => template.exerciseIds.includes(exercise.id));
+
+    const orderedExercises: Exercise[] = [];
+    template.exerciseIds.forEach((id) => {
+        const exercise = exercises.find((e) => id === e.id);
+        if (exercise) {
+            orderedExercises.push(exercise);
+        }
+    });
+
+    return orderedExercises;
 }
 
 export const getExercisesForTemplateSelector: ParametricSelector<LocalStore, WorkoutTemplate, Exercise[]> = createSelector(


### PR DESCRIPTION
##  🎫  Jira Ticket:
https://gundyops.atlassian.net/browse/SOH-45

## Description:
Fixed ordering of templates. Templates will now be added/displayed in the order the exercises were selected in.