### PR TITLE
Unify history lists on the 2.0 card style with year-aware date headers

### DIFF
--- a/src/components/PreviousEntryListItem/index.styled.ts
+++ b/src/components/PreviousEntryListItem/index.styled.ts
@@ -2,56 +2,66 @@ import {StyleSheet} from 'react-native'
 
 import BorderRadius from '@styles/borderRadius'
 import FontSize from '@styles/fontSize'
+import Shadow from '@styles/shadow'
 import Spacing from '@styles/spacing'
 import {Theme} from '@styles/theme'
 
 export default StyleSheet.create({
   container: {
-    padding: Spacing.SMALL,
-    paddingBottom: Spacing.X_SMALL,
-    borderRadius: BorderRadius.SECTION,
-    borderWidth: 1,
-    borderColor: Theme.colors.border,
-    marginBottom: Spacing.MEDIUM
+    ...Shadow.CARD,
+    backgroundColor: Theme.colors.card,
+    borderRadius: BorderRadius.CARD_LG,
+    padding: Spacing.MEDIUM,
+    marginBottom: Spacing.SMALL
   },
   day: {
     fontSize: FontSize.H3,
+    fontWeight: '700',
+    color: Theme.colors.text,
     marginBottom: Spacing.SMALL
   },
   headerChipRow: {
     flexDirection: 'row'
   },
   columnLabelRow: {
-    marginTop: Spacing.MEDIUM,
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginBottom: Spacing.SMALL
+    marginTop: Spacing.MEDIUM,
+    paddingBottom: Spacing.X_SMALL,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Theme.colors.hairline
   },
-  column1Label: {
-    marginLeft: Spacing.X_SMALL,
-    fontSize: FontSize.H2,
-    fontWeight: 'bold'
-  },
-  column2Label: {
-    marginRight: Spacing.X_SMALL,
-    fontSize: FontSize.H2,
-    fontWeight: 'bold'
+  columnLabel: {
+    fontSize: FontSize.OVERLINE,
+    fontWeight: '600',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    color: Theme.colors.textMuted
   },
   subItem: {
-    backgroundColor: Theme.colors.tertiary,
-    borderRadius: BorderRadius.SECTION,
-    marginBottom: Spacing.XX_SMALL,
-    paddingLeft: Spacing.SMALL,
-    paddingRight: Spacing.SMALL,
-    paddingTop: Spacing.XX_SMALL,
-    paddingBottom: Spacing.XX_SMALL
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.SMALL,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Theme.colors.hairline
+  },
+  subItemLast: {
+    borderBottomWidth: 0,
+    paddingBottom: 0
+  },
+  subItemInfo: {
+    flex: 1,
+    marginRight: Spacing.SMALL
   },
   subItemTitle: {
-    fontWeight: 'bold'
+    fontSize: FontSize.BODY,
+    fontWeight: '600',
+    color: Theme.colors.text
   },
   subItemSubtitle: {
-    marginTop: Spacing.XX_SMALL,
-    fontWeight: '200'
+    fontSize: FontSize.CAPTION,
+    color: Theme.colors.textMuted,
+    marginTop: Spacing.XX_SMALL
   },
   emptyStateTitle: {
     fontSize: FontSize.H1,

--- a/src/components/PreviousEntryListItem/index.tsx
+++ b/src/components/PreviousEntryListItem/index.tsx
@@ -28,16 +28,18 @@ const PreviousEntryListItem = <T extends object>(props: Props<T>) => {
       <View style={styles.headerChipRow}>{headerChip}</View>
 
       <View style={styles.columnLabelRow}>
-        <Text style={styles.column1Label}>{column1Label}</Text>
+        <Text style={styles.columnLabel}>{column1Label}</Text>
 
-        <Text style={styles.column2Label}>{column2Label}</Text>
+        <Text style={styles.columnLabel}>{column2Label}</Text>
       </View>
 
       {subItems.map((item: T, i) => (
-        <View key={i} style={styles.subItem}>
-          <Text style={styles.subItemTitle}>{getTitleForItem(item)}</Text>
+        <View key={i} style={[styles.subItem, i === subItems.length - 1 && styles.subItemLast]}>
+          <View style={styles.subItemInfo}>
+            <Text style={styles.subItemTitle}>{getTitleForItem(item)}</Text>
 
-          <Text style={styles.subItemSubtitle}>{getSubtitleForItem(item)}</Text>
+            <Text style={styles.subItemSubtitle}>{getSubtitleForItem(item)}</Text>
+          </View>
 
           {getChipForItem(item)}
         </View>

--- a/src/screens/MacrosHistory/__tests__/index.util.test.ts
+++ b/src/screens/MacrosHistory/__tests__/index.util.test.ts
@@ -7,7 +7,6 @@ import {
   buildLast7DayKeys,
   chartMaxCalories,
   clampBarIndex,
-  formatDayTitle,
   formatMacroLine,
   formatScrubDayLabel,
   goalLinePct,
@@ -160,16 +159,6 @@ describe('isNearGoal', () => {
 
   it('is false when there is no goal', () => {
     expect(isNearGoal(500, 0)).toBe(false)
-  })
-})
-
-describe('formatDayTitle', () => {
-  it('formats a day key as weekday, month and day', () => {
-    expect(formatDayTitle('2026-07-02')).toBe('Thursday, July 2')
-  })
-
-  it('ignores any time component', () => {
-    expect(formatDayTitle('2026-06-28T00:00:00.000Z')).toBe('Sunday, June 28')
   })
 })
 

--- a/src/screens/MacrosHistory/components/DayBreakdownCard/index.tsx
+++ b/src/screens/MacrosHistory/components/DayBreakdownCard/index.tsx
@@ -3,13 +3,14 @@ import React from 'react'
 import {View} from 'react-native'
 
 import {DailySummary} from '@data/models/DailyMacros'
+import {formatDayTitle} from '@utility/DateUtility'
 
 import Text from '@components/Text'
 
 import {CALORIES_COLUMN_LABEL, MEAL_COLUMN_LABEL} from '@constants/strings'
 
 import styles from './index.styled'
-import {formatDayTitle, formatMacroLine} from '../../index.util'
+import {formatMacroLine} from '../../index.util'
 
 interface Props {
   day: DailySummary
@@ -22,7 +23,7 @@ const DayBreakdownCard = ({day}: Props) => {
     <View style={styles.card}>
       <View style={styles.headerRow}>
         <View style={styles.dayColumn}>
-          <Text style={styles.dayTitle}>{formatDayTitle(day.date)}</Text>
+          <Text style={styles.dayTitle}>{formatDayTitle(day.date, new Date().getFullYear())}</Text>
 
           <Text style={styles.daySubtitle}>{formatMacroLine(day.protein, day.carbs, day.fat)}</Text>
         </View>

--- a/src/screens/MacrosHistory/index.util.ts
+++ b/src/screens/MacrosHistory/index.util.ts
@@ -97,17 +97,6 @@ export const goalLinePct = (goal: number, chartMax: number): number => {
 export const isNearGoal = (calories: number, goal: number): boolean =>
   goal > 0 && calories >= goal * NEAR_GOAL_THRESHOLD
 
-/**
- * Formats a 'yyyy-MM-dd' day key as e.g. 'Thursday, July 2'. Builds the Date
- * from its parts so the string isn't parsed as UTC midnight, which would
- * display the previous calendar day in UTC+ timezones.
- */
-export const formatDayTitle = (isoDate: string): string => {
-  const [year, month, day] = isoDate.split('T')[0].split('-').map(Number)
-
-  return format(new Date(year, month - 1, day), 'EEEE, MMMM d')
-}
-
 /** Formats macro grams as e.g. '92g P · 188g C · 61g F'. */
 export const formatMacroLine = (protein: number, carbs: number, fat: number): string =>
   `${protein}g P · ${carbs}g C · ${fat}g F`

--- a/src/screens/PreviousWorkoutEntries/components/BestSetChip/index.styled.ts
+++ b/src/screens/PreviousWorkoutEntries/components/BestSetChip/index.styled.ts
@@ -4,14 +4,6 @@ import Spacing from '@styles/spacing'
 
 export default StyleSheet.create({
   chip: {
-    alignSelf: 'flex-end',
-    position: 'absolute',
-    marginTop: Spacing.X_SMALL,
-    marginBottom: Spacing.X_SMALL,
-    paddingLeft: Spacing.X_SMALL,
-    marginRight: Spacing.X_SMALL,
-    top: 0,
-    right: 0,
-    bottom: 0
+    paddingLeft: Spacing.X_SMALL
   }
 })

--- a/src/screens/PreviousWorkoutEntries/index.styled.ts
+++ b/src/screens/PreviousWorkoutEntries/index.styled.ts
@@ -8,6 +8,10 @@ export default StyleSheet.create({
   list: {
     flex: 1
   },
+  listContent: {
+    paddingHorizontal: Spacing.GUTTER,
+    paddingBottom: Spacing.LARGE
+  },
   // Mirrors the Macros history screen title
   title: {
     fontSize: FontSize.SCREEN_TITLE,

--- a/src/screens/PreviousWorkoutEntries/index.tsx
+++ b/src/screens/PreviousWorkoutEntries/index.tsx
@@ -9,7 +9,7 @@ import {useWeightUnitLabel} from '@hooks/userData/useWeightUnitLabel'
 import {useWorkoutSummariesInfiniteQuery} from '@queries/workouts/useWorkoutSummariesInfiniteQuery'
 import Spacing from '@styles/spacing'
 import {Theme} from '@styles/theme'
-import {formatDateUTC} from '@utility/DateUtility'
+import {formatDayTitle} from '@utility/DateUtility'
 import {formatSecondsAsDuration} from '@utility/formatSecondsAsDuration'
 
 import Chip from '@components/Chip'
@@ -77,7 +77,7 @@ const PreviousWorkoutEntries = () => {
       column1Label={EXERCISE_LABEL}
       column2Label={BEST_SET_LABEL}
       subItems={item.exercises}
-      day={formatDateUTC(item.day)}
+      day={formatDayTitle(item.day, new Date().getFullYear())}
       headerChip={
         <>
           {item.totalWeight > 0 && (
@@ -147,6 +147,7 @@ const PreviousWorkoutEntries = () => {
 
         <FlatList
           style={styles.list}
+          contentContainerStyle={styles.listContent}
           showsVerticalScrollIndicator={false}
           data={summaries}
           renderItem={renderItem}

--- a/src/utility/DateUtility.ts
+++ b/src/utility/DateUtility.ts
@@ -6,18 +6,16 @@ export const getCurrentDateISO = () => format(new Date(), 'yyyy-MM-dd')
 
 export const formatDate = (date: number) => format(date, 'MMMM dd, yyyy')
 
-export const formatDateUTC = (isoDate: string) => {
-  const [year, month, day] = isoDate.split('T')[0].split('-')
-  // Build the date in UTC so formatting with timeZone: 'UTC' shows the same
-  // calendar day regardless of the device's timezone offset
-  const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)))
+/**
+ * Formats a 'yyyy-MM-dd' day key as e.g. 'Thursday, July 2', appending the
+ * year ('Saturday, July 5, 2025') when it differs from `currentYear`. Builds
+ * the Date from its parts so the string isn't parsed as UTC midnight, which
+ * would display the previous calendar day in UTC+ timezones.
+ */
+export const formatDayTitle = (isoDate: string, currentYear: number): string => {
+  const [year, month, day] = isoDate.split('T')[0].split('-').map(Number)
 
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: '2-digit',
-    timeZone: 'UTC'
-  })
+  return format(new Date(year, month - 1, day), year === currentYear ? 'EEEE, MMMM d' : 'EEEE, MMMM d, yyyy')
 }
 
 export const compareIsoDateStrings = (a: string, b: string): boolean => {

--- a/src/utility/__tests__/DateUtility.test.ts
+++ b/src/utility/__tests__/DateUtility.test.ts
@@ -6,8 +6,8 @@ import {
   formatDate,
   formatDateToMonthDay,
   formatDateToMonthDayName,
-  formatDateUTC,
   formatDayMonthDay,
+  formatDayTitle,
   formatIsoDayMonthDay,
   getCurrentDate,
   getCurrentDateISO,
@@ -60,19 +60,17 @@ describe('formatDate', () => {
   })
 })
 
-describe('formatDateUTC', () => {
-  it('formats the date portion of an ISO datetime string', () => {
-    expect(formatDateUTC('2026-07-03T23:59:59.000Z')).toBe('July 03, 2026')
+describe('formatDayTitle', () => {
+  it('omits the year for dates in the current year', () => {
+    expect(formatDayTitle('2026-07-02', 2026)).toBe('Thursday, July 2')
   })
 
-  it('formats a date-only ISO string', () => {
-    expect(formatDateUTC('2025-12-25')).toBe('December 25, 2025')
+  it('appends the year for dates outside the current year', () => {
+    expect(formatDayTitle('2025-07-05', 2026)).toBe('Saturday, July 5, 2025')
   })
 
-  it('shows the ISO calendar day regardless of the device timezone', () => {
-    // Regression: building the date at local midnight shifted the display to
-    // the previous day on UTC+ devices
-    expect(formatDateUTC('2026-01-01T00:00:00.000Z')).toBe('January 01, 2026')
+  it('ignores any time component', () => {
+    expect(formatDayTitle('2026-06-28T00:00:00.000Z', 2026)).toBe('Sunday, June 28')
   })
 })
 


### PR DESCRIPTION
## What

- **Workout History → 2.0 card style.** Restyled the shared `PreviousEntryListItem` to match the Macros history `DayBreakdownCard`: shadowed card on the page background, uppercase overline column labels, hairline row dividers, and the best-set chip rendered inline on the right of each exercise row (replacing the old absolute-positioned pill layout). The total weight / bodyweight reps / duration header chips are kept. The list also gets the same screen gutters as Macros history.
- **Year-aware date headers on both history screens.** `formatDayTitle` is promoted to `src/utility/DateUtility.ts` and takes the current year: current-year dates render as "Sunday, July 5", anything older as "Saturday, July 5, 2025". Without this, migrated 2025 entries looked like out-of-place duplicates in the middle of the list. The workout history's old always-on-year formatter (`formatDateUTC`) is removed with its only consumer.

## Why

Old Firebase logs migrated into Postgres surface pre-2026 days in both history lists; with no year on the headers they read as sorting bugs. And the two history screens had drifted apart visually — Macros history shipped with the 2.0 design while workout History still had the pre-redesign bordered cards.

## Testing

- `formatDayTitle` unit tests cover current-year, prior-year, and time-component inputs; Macros util tests updated for the moved helper. 65 tests pass, `tsc --noEmit` clean.
- Verified live in the iOS simulator: workout History renders the new card (day title, chips, EXERCISE/BEST SET columns, inline best-set chips) and visually matches Macros history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)