### PR TITLE
Return to Add Food screen after adding a food to a meal

### DIFF
--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -753,6 +753,8 @@ export const TOAST_SAVE_AI_FOODS_ADD = 'Add'
 
 export const TOAST_SAVED_TO_FOODS = 'Saved to your foods!'
 
+export const TOAST_ADDED_TO_MEAL_PREFIX = 'Added to'
+
 export const AI_FREE_FOR_NOW_CAPTION = 'Free for a limited time'
 
 export const AI_DAILY_LIMIT_TOAST = "You've used today's free AI estimates. More tomorrow!"

--- a/src/screens/FoodDetail/index.tsx
+++ b/src/screens/FoodDetail/index.tsx
@@ -23,6 +23,7 @@ import {
   CAL_PER_SERVING_SUFFIX,
   SERVINGS_HEADER,
   THIS_ADDS_LABEL,
+  TOAST_ADDED_TO_MEAL_PREFIX,
   TOAST_GENERIC_ERROR,
   UPDATE_SERVINGS_BUTTON_TEXT
 } from '@constants/strings'
@@ -125,7 +126,11 @@ const FoodDetailScreen = () => {
         }
       })
 
-      navigation.pop(2)
+      // Land back on Add Food (not Macros) so more items can be added to the
+      // same meal without re-entering the flow
+      navigation.goBack()
+
+      showToast('success', `${TOAST_ADDED_TO_MEAL_PREFIX} ${params.mealName}`, food.name)
     } catch {
       showToast('error', TOAST_GENERIC_ERROR)
     }


### PR DESCRIPTION
## Summary
- After adding a food from the Food Detail screen, the app now pops back to the **Add Food** screen instead of all the way to the Macros screen, so users can quickly add multiple items to the same meal.
- Shows a success toast — "Added to {meal}" with the food name — which also fires success haptics via the existing `showToast` helper.
- Adds a `TOAST_ADDED_TO_MEAL_PREFIX` string constant.

## Test plan
- [ ] Macros → tap a meal's add button → pick a food → Add: verify you land back on Add Food (not Macros) and see the toast + haptic.
- [ ] Add a branded food the same way (exercises the create-then-log path).
- [ ] Verify "Update servings" path (editing an existing entry) still pops back one screen as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)