### PR TITLE
Env-driven API base URL: dev builds hit dev API, prod builds hit prod

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -5,16 +5,19 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "environment": "development"
     },
     "preview": {
       "distribution": "internal",
+      "environment": "development",
       "ios": {
         "simulator": true
       }
     },
     "testing": {
       "distribution": "internal",
+      "environment": "development",
       "ios": {
         "resourceClass": "m-medium"
       }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -1,4 +1,9 @@
-const baseApiUrl = 'https://stateofhealthapi.com/api'
+import { SOH_API_BASE_URL } from '@env'
+
+// Host comes from the environment: local .env for `expo run`, EAS environment
+// variables for builds (development/preview → dev API, production → prod).
+// Fallback keeps release builds safe if the var is ever missing.
+const baseApiUrl = `${SOH_API_BASE_URL || 'https://stateofhealthapi.com'}/api`
 
 const Endpoints = {
   Exercises: `${baseApiUrl}/exercises`,


### PR DESCRIPTION
- `endpoints.ts` now reads `SOH_API_BASE_URL` from the env (react-native-dotenv), appending `/api`; falls back to prod if unset so release builds can't break
- `eas.json`: development/preview/testing profiles pinned to the EAS `development` environment (its `SOH_API_BASE_URL` is set to `https://dev.stateofhealthapi.com`); production unchanged and verified pointing at prod
- Local `.env` (gitignored) now points at the dev API for `expo run` / metro — first start needs `npx expo start -c` to bust the babel cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)