### PR TITLE
Identify Apple Health in Activity tab UI (App Review 2.5.1)

### DIFF
--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -485,9 +485,12 @@ export const BURN_INFO_DISCLAIMER =
 
 export const ACTIVITY_CONNECT_HEALTH_TITLE = 'Connect Apple Health'
 
-export const ACTIVITY_CONNECT_HEALTH_BODY = 'Allow step access so your daily movement counts toward your activity.'
+export const ACTIVITY_CONNECT_HEALTH_BODY =
+  'Allow access to your Apple Health step count so your daily movement counts toward your activity.'
 
 export const ACTIVITY_CONNECT_HEALTH_BUTTON = 'Connect'
+
+export const ACTIVITY_STEPS_SOURCE_TEXT = 'Steps from Apple Health'
 
 export const ACTIVITY_HEALTH_DENIED_TITLE = 'Step access is off'
 

--- a/src/screens/Progress/components/StepsCard/index.styled.ts
+++ b/src/screens/Progress/components/StepsCard/index.styled.ts
@@ -116,5 +116,11 @@ export default StyleSheet.create({
   barLabelActive: {
     color: Theme.colors.accentGreen,
     fontWeight: '600'
+  },
+  sourceText: {
+    fontSize: FontSize.CAPTION,
+    color: Theme.colors.textMuted,
+    textAlign: 'center',
+    marginTop: Spacing.SMALL
   }
 })

--- a/src/screens/Progress/components/StepsCard/index.tsx
+++ b/src/screens/Progress/components/StepsCard/index.tsx
@@ -10,7 +10,12 @@ import Animated, {FadeIn, FadeOut, runOnJS, useSharedValue} from 'react-native-r
 import Text from '@components/Text'
 import TickerText from '@components/TickerText'
 
-import {ACTIVITY_STEP_GOAL_TEXT, ACTIVITY_VS_AVG_TEXT, stringWithParameters} from '@constants/strings'
+import {
+  ACTIVITY_STEP_GOAL_TEXT,
+  ACTIVITY_STEPS_SOURCE_TEXT,
+  ACTIVITY_VS_AVG_TEXT,
+  stringWithParameters
+} from '@constants/strings'
 
 import styles, {barHeight, progressFillWidth} from './index.styled'
 import {clampBarIndex, computeGoalProgress, computeStepBars, formatDayDate, formatDayLabel} from './index.util'
@@ -134,6 +139,8 @@ const StepsCard = ({weekSteps, stepGoal, vsAveragePct}: Props) => {
           ))}
         </View>
       </GestureDetector>
+
+      <Text style={styles.sourceText}>{ACTIVITY_STEPS_SOURCE_TEXT}</Text>
     </View>
   )
 }


### PR DESCRIPTION
## Summary
Apple's 2.5.1 rejection asks that HealthKit functionality be clearly identified in the app's UI (not just permission strings). This strengthens the Activity tab's Apple Health identification:

- The connect card body now names Apple Health explicitly ("Allow access to your Apple Health step count…") — previously only the title mentioned it
- The steps card shows a persistent "Steps from Apple Health" caption under the weekly bars, so the integration stays identified after the user connects, not just in the pre-connect empty state

With this, Progress → Activity identifies Apple Health in the connect card title, connect card body, and on the steps card itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)