### PR TITLE
Harden offline run sync and surface unsynced runs in the UI

### DIFF
--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -307,6 +307,8 @@ export const RUNS_BADGE_BEST_PACE = 'best pace'
 
 export const RUNS_BADGE_LONGEST = 'longest'
 
+export const RUNS_BADGE_NOT_BACKED_UP = 'not backed up'
+
 export const RUNS_PACE_CAPTION = '%0 pace'
 
 export const RUNS_EMPTY_TITLE = 'No runs yet'
@@ -489,8 +491,6 @@ export const ACTIVITY_CONNECT_HEALTH_BODY =
   'Allow access to your Apple Health step count so your daily movement counts toward your activity.'
 
 export const ACTIVITY_CONNECT_HEALTH_BUTTON = 'Connect'
-
-export const ACTIVITY_STEPS_SOURCE_TEXT = 'Steps from Apple Health'
 
 export const ACTIVITY_HEALTH_DENIED_TITLE = 'Step access is off'
 

--- a/src/screens/Progress/components/StepsCard/index.styled.ts
+++ b/src/screens/Progress/components/StepsCard/index.styled.ts
@@ -116,11 +116,5 @@ export default StyleSheet.create({
   barLabelActive: {
     color: Theme.colors.accentGreen,
     fontWeight: '600'
-  },
-  sourceText: {
-    fontSize: FontSize.CAPTION,
-    color: Theme.colors.textMuted,
-    textAlign: 'center',
-    marginTop: Spacing.SMALL
   }
 })

--- a/src/screens/Progress/components/StepsCard/index.tsx
+++ b/src/screens/Progress/components/StepsCard/index.tsx
@@ -10,12 +10,7 @@ import Animated, {FadeIn, FadeOut, runOnJS, useSharedValue} from 'react-native-r
 import Text from '@components/Text'
 import TickerText from '@components/TickerText'
 
-import {
-  ACTIVITY_STEP_GOAL_TEXT,
-  ACTIVITY_STEPS_SOURCE_TEXT,
-  ACTIVITY_VS_AVG_TEXT,
-  stringWithParameters
-} from '@constants/strings'
+import {ACTIVITY_STEP_GOAL_TEXT, ACTIVITY_VS_AVG_TEXT, stringWithParameters} from '@constants/strings'
 
 import styles, {barHeight, progressFillWidth} from './index.styled'
 import {clampBarIndex, computeGoalProgress, computeStepBars, formatDayDate, formatDayLabel} from './index.util'
@@ -139,8 +134,6 @@ const StepsCard = ({weekSteps, stepGoal, vsAveragePct}: Props) => {
           ))}
         </View>
       </GestureDetector>
-
-      <Text style={styles.sourceText}>{ACTIVITY_STEPS_SOURCE_TEXT}</Text>
     </View>
   )
 }

--- a/src/screens/Runs/components/LatestRunCard/index.styled.ts
+++ b/src/screens/Runs/components/LatestRunCard/index.styled.ts
@@ -46,6 +46,11 @@ export default StyleSheet.create({
     paddingVertical: Spacing.XX_SMALL + 1,
     paddingHorizontal: Spacing.X_SMALL + 2
   },
+  pendingBadge: {
+    left: undefined,
+    right: Spacing.SMALL,
+    backgroundColor: Theme.colors.error
+  },
   latestBadgeText: {
     fontSize: FontSize.OVERLINE,
     fontWeight: '700',

--- a/src/screens/Runs/components/LatestRunCard/index.tsx
+++ b/src/screens/Runs/components/LatestRunCard/index.tsx
@@ -14,6 +14,7 @@ import {
   RUN_STAT_MILES_LABEL,
   RUN_STAT_PACE_LABEL,
   RUN_STAT_TIME_LABEL,
+  RUNS_BADGE_NOT_BACKED_UP,
   RUNS_LATEST_BADGE,
   RUNS_MAP_PLACEHOLDER
 } from '@constants/strings'
@@ -22,6 +23,7 @@ import styles from './index.styled'
 
 interface Props {
   run: Run
+  pending?: boolean
 }
 
 interface Stat {
@@ -31,7 +33,7 @@ interface Stat {
 
 const STRIPE_SIZE = 20
 
-const LatestRunCard = ({run}: Props) => {
+const LatestRunCard = ({run, pending = false}: Props) => {
   const stats: Stat[] = [
     {value: run.distanceMiles.toFixed(2), label: RUN_STAT_MILES_LABEL},
     {value: formatRunDuration(run.durationSeconds), label: RUN_STAT_TIME_LABEL},
@@ -64,6 +66,12 @@ const LatestRunCard = ({run}: Props) => {
         <View style={styles.latestBadge}>
           <Text style={styles.latestBadgeText}>{RUNS_LATEST_BADGE}</Text>
         </View>
+
+        {pending && (
+          <View style={[styles.latestBadge, styles.pendingBadge]}>
+            <Text style={styles.latestBadgeText}>{RUNS_BADGE_NOT_BACKED_UP}</Text>
+          </View>
+        )}
       </View>
 
       <View style={styles.statStrip}>

--- a/src/screens/Runs/components/RunHistoryListItem/index.styled.ts
+++ b/src/screens/Runs/components/RunHistoryListItem/index.styled.ts
@@ -35,5 +35,8 @@ export default StyleSheet.create({
   },
   badgeTeal: {
     color: Theme.colors.teal
+  },
+  badgeDanger: {
+    color: Theme.colors.error
   }
 })

--- a/src/screens/Runs/components/RunHistoryListItem/index.tsx
+++ b/src/screens/Runs/components/RunHistoryListItem/index.tsx
@@ -11,7 +11,13 @@ import RunIcon from '@components/icons/RunIcon'
 import IconTile from '@components/IconTile'
 import Text from '@components/Text'
 
-import {RUNS_BADGE_BEST_PACE, RUNS_BADGE_LONGEST, RUNS_PACE_CAPTION, stringWithParameters} from '@constants/strings'
+import {
+  RUNS_BADGE_BEST_PACE,
+  RUNS_BADGE_LONGEST,
+  RUNS_BADGE_NOT_BACKED_UP,
+  RUNS_PACE_CAPTION,
+  stringWithParameters
+} from '@constants/strings'
 
 import styles from './index.styled'
 
@@ -20,11 +26,12 @@ export type RunBadge = 'best-pace' | 'longest' | undefined
 interface Props {
   run: Run
   badge?: RunBadge
+  pending?: boolean
 }
 
 const RUN_TILE_SIZE = 38
 
-const RunHistoryListItem = ({run, badge}: Props) => {
+const RunHistoryListItem = ({run, badge, pending = false}: Props) => {
   const title = `${run.distanceMiles.toFixed(2)} mi · ${formatRunDuration(run.durationSeconds)}`
   const caption = `${formatDateToMonthDayName(run.date)} · ${stringWithParameters(RUNS_PACE_CAPTION, formatPace(run))}`
 
@@ -40,9 +47,11 @@ const RunHistoryListItem = ({run, badge}: Props) => {
         <Text style={styles.caption}>{caption}</Text>
       </View>
 
-      {badge === 'best-pace' && <Text style={styles.badge}>{RUNS_BADGE_BEST_PACE}</Text>}
+      {pending && <Text style={[styles.badge, styles.badgeDanger]}>{RUNS_BADGE_NOT_BACKED_UP}</Text>}
 
-      {badge === 'longest' && <Text style={[styles.badge, styles.badgeTeal]}>{RUNS_BADGE_LONGEST}</Text>}
+      {!pending && badge === 'best-pace' && <Text style={styles.badge}>{RUNS_BADGE_BEST_PACE}</Text>}
+
+      {!pending && badge === 'longest' && <Text style={[styles.badge, styles.badgeTeal]}>{RUNS_BADGE_LONGEST}</Text>}
     </View>
   )
 }

--- a/src/screens/Runs/index.tsx
+++ b/src/screens/Runs/index.tsx
@@ -96,7 +96,7 @@ const RunsScreen = () => {
       onSwipeActivated={() => listSwipeItemManager.closeRow(run, index)}
       onDeletePressed={() => handleDeleteRequested(run)}>
       <TouchableOpacity activeOpacity={0.7} onPress={() => handleRunPress(run)}>
-        <RunHistoryListItem run={run} badge={badge} />
+        <RunHistoryListItem run={run} badge={badge} pending={pendingLocalIds.has(run.id)} />
       </TouchableOpacity>
     </SwipeDeleteListItem>
   )
@@ -153,7 +153,7 @@ const RunsScreen = () => {
 
             {latestRun && (
               <TouchableOpacity activeOpacity={0.8} onPress={() => handleRunPress(latestRun)}>
-                <LatestRunCard run={latestRun} />
+                <LatestRunCard run={latestRun} pending={pendingLocalIds.has(latestRun.id)} />
               </TouchableOpacity>
             )}
 

--- a/src/screens/Runs/useRunsFocusSync.ts
+++ b/src/screens/Runs/useRunsFocusSync.ts
@@ -18,6 +18,11 @@ import {RUN_RECOVERED_TOAST} from '@constants/strings'
 
 type RunsNavigationProp = NativeStackNavigationProp<RunsStackParamList, typeof Screens.RUNS>
 
+// Parked runs (sync attempts exhausted) get one fresh set of attempts per app
+// launch — module-level so it survives screen remounts but resets with the JS
+// context.
+let hasRetriedParkedThisLaunch = false
+
 /**
  * Everything the Runs screen kicks off when it gains focus: the foreground
  * permission pre-request, the pending-local-runs read, crash recovery, and a
@@ -83,7 +88,10 @@ export const useRunsFocusSync = () => {
 
       // Best-effort background push so pending runs clear out of the local
       // bucket on their own; the mutation invalidates the runs query.
-      syncRuns(undefined, {onSuccess: () => refreshLocalRuns()})
+      const retryParked = !hasRetriedParkedThisLaunch
+
+      hasRetriedParkedThisLaunch = true
+      syncRuns({retryParked}, {onSuccess: () => refreshLocalRuns()})
     }, [refreshLocalRuns, handleRecovery, syncRuns])
   )
 

--- a/src/service/runs/__tests__/syncOfflineRuns.test.ts
+++ b/src/service/runs/__tests__/syncOfflineRuns.test.ts
@@ -28,9 +28,16 @@ jest.mock('@utility/CrashUtility', () => ({
   default: {recordError: jest.fn()}
 }))
 
+jest.mock('@utility/isServerFailureError', () => ({
+  isServerFailureError: jest.fn(),
+  isPermanentRejectionError: jest.fn()
+}))
+
 const mockCreateRun = jest.mocked(createRun)
 const mockUpdateRun = jest.mocked(updateRun)
 const mockStorage = jest.mocked(offlineRunStorageService)
+const mockIsServerFailureError = require('@utility/isServerFailureError').isServerFailureError as jest.Mock
+const mockIsPermanentRejectionError = require('@utility/isServerFailureError').isPermanentRejectionError as jest.Mock
 
 const makeRun = (overrides: Partial<RunRecord> = {}): RunRecord => ({
   localId: 'local-1',
@@ -50,6 +57,8 @@ describe('syncOfflineRuns', () => {
     jest.clearAllMocks()
     mockStorage.save.mockResolvedValue(undefined)
     mockStorage.deleteAllSynced.mockResolvedValue(undefined)
+    mockIsServerFailureError.mockReturnValue(false)
+    mockIsPermanentRejectionError.mockReturnValue(false)
   })
 
   it('creates unsynced runs without a remote id and marks them synced', async () => {
@@ -95,15 +104,45 @@ describe('syncOfflineRuns', () => {
     expect(mockCreateRun).not.toHaveBeenCalled()
   })
 
-  it('increments the attempt counter on failure and keeps the run', async () => {
+  it('increments the attempt counter on a server failure (5xx) and keeps the run', async () => {
     const run = makeRun({syncAttempts: 1})
 
     mockStorage.readAll.mockResolvedValue([run])
     mockCreateRun.mockRejectedValue(new Error('server down'))
+    mockIsServerFailureError.mockReturnValue(true)
 
     await syncOfflineRuns()
 
     expect(mockStorage.save).toHaveBeenCalledWith(expect.objectContaining({localId: 'local-1', syncAttempts: 2}))
+    expect(mockStorage.deleteByLocalId).not.toHaveBeenCalled()
+  })
+
+  it('aborts the pass on a network/offline error without burning any attempts', async () => {
+    const first = makeRun({localId: 'local-1'})
+    const second = makeRun({localId: 'local-2'})
+
+    mockStorage.readAll.mockResolvedValue([first, second])
+    mockCreateRun.mockRejectedValue(new Error('network request failed'))
+
+    await syncOfflineRuns()
+
+    // One probe request tells us the server is unreachable — the second run
+    // is not attempted and neither run's counter moves.
+    expect(mockCreateRun).toHaveBeenCalledTimes(1)
+    expect(mockStorage.save).not.toHaveBeenCalledWith(expect.objectContaining({syncAttempts: 1}))
+    expect(mockStorage.deleteByLocalId).not.toHaveBeenCalled()
+  })
+
+  it('parks a run immediately on a permanent rejection (4xx)', async () => {
+    const run = makeRun({syncAttempts: 0})
+
+    mockStorage.readAll.mockResolvedValue([run])
+    mockCreateRun.mockRejectedValue(new Error('bad request'))
+    mockIsPermanentRejectionError.mockReturnValue(true)
+
+    await syncOfflineRuns()
+
+    expect(mockStorage.save).toHaveBeenCalledWith(expect.objectContaining({localId: 'local-1', syncAttempts: 3}))
     expect(mockStorage.deleteByLocalId).not.toHaveBeenCalled()
   })
 
@@ -115,6 +154,53 @@ describe('syncOfflineRuns', () => {
     expect(mockCreateRun).not.toHaveBeenCalled()
     expect(mockStorage.deleteByLocalId).not.toHaveBeenCalled()
     expect(mockStorage.save).not.toHaveBeenCalled()
+  })
+
+  it('gives parked runs a fresh set of attempts when retryParked is set', async () => {
+    const run = makeRun({syncAttempts: 3})
+
+    mockStorage.readAll.mockResolvedValue([run])
+    mockCreateRun.mockResolvedValue({run: {...run, id: 'remote-1', synced: true}, newRecords: []})
+
+    await syncOfflineRuns({retryParked: true})
+
+    expect(mockCreateRun).toHaveBeenCalledWith(run)
+    expect(mockStorage.save).toHaveBeenCalledWith(expect.objectContaining({synced: true, syncAttempts: 0}))
+  })
+
+  it('restarts the attempt counter from zero when a retried parked run fails again', async () => {
+    const run = makeRun({syncAttempts: 3})
+
+    mockStorage.readAll.mockResolvedValue([run])
+    mockCreateRun.mockRejectedValue(new Error('server down'))
+    mockIsServerFailureError.mockReturnValue(true)
+
+    await syncOfflineRuns({retryParked: true})
+
+    expect(mockStorage.save).toHaveBeenCalledWith(expect.objectContaining({localId: 'local-1', syncAttempts: 1}))
+  })
+
+  it('resurrects only the newest parked runs per pass, leaving the rest parked', async () => {
+    const parked = Array.from({length: 12}, (_, i) =>
+      makeRun({
+        localId: `local-${i}`,
+        startedAt: `2026-06-${String(i + 1).padStart(2, '0')}T10:00:00.000Z`,
+        syncAttempts: 3
+      })
+    )
+
+    mockStorage.readAll.mockResolvedValue(parked)
+    mockCreateRun.mockImplementation(async run => ({run: {...run, id: `remote-${run.localId}`, synced: true}, newRecords: []}))
+
+    await syncOfflineRuns({retryParked: true})
+
+    // 12 parked, cap is 10 — the two oldest (June 1 and 2) stay parked
+    expect(mockCreateRun).toHaveBeenCalledTimes(10)
+
+    const attempted = mockCreateRun.mock.calls.map(([run]) => run.localId)
+
+    expect(attempted).not.toContain('local-0')
+    expect(attempted).not.toContain('local-1')
   })
 
   it('sweeps synced records at the end', async () => {

--- a/src/service/runs/syncOfflineRuns.ts
+++ b/src/service/runs/syncOfflineRuns.ts
@@ -3,8 +3,15 @@ import {createRun} from '@queries/api/runs/createRun'
 import {updateRun} from '@queries/api/runs/updateRun'
 import offlineRunStorageService from '@service/runs/OfflineRunStorageService'
 import CrashUtility from '@utility/CrashUtility'
+import {isPermanentRejectionError, isServerFailureError} from '@utility/isServerFailureError'
 
 const MAX_SYNC_ATTEMPTS = 3
+// Bounds the per-launch network cost of a long-failing backlog: only this
+// many parked runs (newest first) are resurrected per retryParked pass.
+// Older parked runs stay stored and badged, they just stop costing requests.
+const MAX_PARKED_RETRIES_PER_PASS = 10
+
+const isParked = (run: RunRecord): boolean => !run.synced && !run.draft && (run.syncAttempts ?? 0) >= MAX_SYNC_ATTEMPTS
 
 /**
  * Bounded-retry background sync of every unsynced local run. Mirrors
@@ -12,16 +19,36 @@ const MAX_SYNC_ATTEMPTS = 3
  * to a calendar day the way a WorkoutDay is.
  *
  * - Drafts (awaiting the user's Save/Discard decision) are never pushed.
- * - A run that fails MAX_SYNC_ATTEMPTS times is parked (skipped, kept on
- *   disk) rather than deleted — a transient server outage must never destroy
- *   a user's run. Parked runs stay visible as pending and can be swiped away.
+ * - Only server failures (5xx) burn an attempt; being offline retries
+ *   indefinitely — losing signal for a weekend must never park a run. An
+ *   offline error also aborts the whole pass: if one request can't reach the
+ *   server, neither can the rest, so a backlog costs one request, not N.
+ * - A run that fails MAX_SYNC_ATTEMPTS times (or the server rejects it with
+ *   a 4xx) is parked (skipped, kept on disk) rather than deleted. Parking
+ *   only means "stop hammering for now": callers pass `retryParked` to grant
+ *   the newest MAX_PARKED_RETRIES_PER_PASS parked runs a fresh set of
+ *   attempts (the Runs screen does this once per app launch), so recent runs
+ *   are never abandoned and old failures never flood the network.
  */
-export default async function syncOfflineRuns(): Promise<void> {
+export default async function syncOfflineRuns({retryParked = false}: {retryParked?: boolean} = {}): Promise<void> {
   const runs = await offlineRunStorageService.readAll()
+
+  const resurrectedIds = new Set(
+    retryParked
+      ? runs
+          .filter(isParked)
+          .sort((a, b) => Date.parse(b.startedAt) - Date.parse(a.startedAt))
+          .slice(0, MAX_PARKED_RETRIES_PER_PASS)
+          .map(run => run.localId)
+      : []
+  )
 
   for (const run of runs) {
     if (run.synced || run.draft) continue
-    if ((run.syncAttempts ?? 0) >= MAX_SYNC_ATTEMPTS) continue
+
+    const attempts = resurrectedIds.has(run.localId) ? 0 : (run.syncAttempts ?? 0)
+
+    if (attempts >= MAX_SYNC_ATTEMPTS) continue
 
     try {
       const result: RunRecord = run.id ? (await updateRun(run)).run : (await createRun(run)).run
@@ -33,9 +60,22 @@ export default async function syncOfflineRuns(): Promise<void> {
       })
     } catch (error) {
       CrashUtility.recordError(error)
+
+      if (isPermanentRejectionError(error)) {
+        // 4xx — retrying can never succeed, so park it immediately
+        await offlineRunStorageService.save({...run, syncAttempts: MAX_SYNC_ATTEMPTS})
+        continue
+      }
+
+      if (!isServerFailureError(error)) {
+        // Network/unknown error (likely offline) — the remaining runs can't
+        // reach the server either. Abort the pass; nobody's attempts burn.
+        break
+      }
+
       await offlineRunStorageService.save({
         ...run,
-        syncAttempts: (run.syncAttempts ?? 0) + 1
+        syncAttempts: attempts + 1
       })
     }
   }


### PR DESCRIPTION
## Why

Two real runs (2.5mi + 1.2mi) were permanently lost last week: the backend 500'd on their payloads (see state-of-health-be #1), `syncOfflineRuns` silently burned its 3 attempts, parked them with no visible indication, and an app reinstall wiped the only copies. Runs are the one domain where the local copy can be the *only* copy — sync failure must be loud and recoverable.

## Sync changes (`syncOfflineRuns`)

Ports the error classification `syncOfflineWorkouts` already had, then goes further:

| Failure | Old behavior | New behavior |
|---|---|---|
| Offline / no response | burned an attempt → could park | **aborts the pass** (1 probe request instead of N), burns nothing |
| 4xx | burned an attempt | parks immediately — identical bytes can't succeed |
| 5xx | burned an attempt | unchanged: 3 attempts, then parked |
| Parked | stranded forever, invisible | **10 newest parked runs get fresh attempts once per app launch** (`retryParked`) |

Design choices worth reviewing:
- **No deletion cap.** A run is ~15KB; storage was never the cost, network was. The per-launch resurrection cap (10 newest) bounds requests without ever destroying user data.
- The launch-scoped `retryParked` flag lives in `useRunsFocusSync` (module-level, resets with the JS context).

## UI

Red **"not backed up"** badge on unsynced runs — history rows (takes precedence over best-pace/longest badges) and a pill on the latest-run card. Driven by the `pendingLocalIds` the Runs screen already computed; the data existed, it just was never shown.

## Also

Removes the "Steps from Apple Health" attribution caption from the steps card (per Kenny). The connect card body copy still names Apple Health explicitly, so guideline 2.5.1 identification is retained pre-connection; if App Review pushes back, restoring the caption is a 3-line revert of this part.

## Testing

- 6 new/updated unit tests: offline abort (probe-only, no attempts burned), 4xx immediate park, 5xx increment, parked resurrection, resurrection cap (12 parked → 10 newest attempted), counter restart after resurrected failure.
- Full suite: 575 tests / 42 suites green. `tsc --noEmit` clean.
- App rebundled and relaunched on the iOS simulator against the dev API.

## Not in this PR

- `syncOfflineWorkouts` parity: it still lacks abort-on-offline and resurrection (its parked workouts are stranded/invisible the same way runs were).
- Manual "retry now" affordance on the badge.
- `app.json` buildNumber bump left uncommitted (belongs with the App Store resubmission work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)