### PR TITLE
Fix App Store 5.1.1 rejection and quarter-step serving stepper

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.stateofhealh.tracker",
       "icon": "./assets/icon.png",
-      "buildNumber": "27",
+      "buildNumber": "28",
       "usesAppleSignIn": true,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -490,7 +490,7 @@ export const ACTIVITY_CONNECT_HEALTH_TITLE = 'Connect Apple Health'
 export const ACTIVITY_CONNECT_HEALTH_BODY =
   'Allow access to your Apple Health step count so your daily movement counts toward your activity.'
 
-export const ACTIVITY_CONNECT_HEALTH_BUTTON = 'Connect'
+export const ACTIVITY_CONNECT_HEALTH_BUTTON = 'Continue'
 
 export const ACTIVITY_HEALTH_DENIED_TITLE = 'Step access is off'
 

--- a/src/screens/FoodDetail/__tests__/index.util.test.ts
+++ b/src/screens/FoodDetail/__tests__/index.util.test.ts
@@ -39,14 +39,14 @@ describe('formatServingsDisplay', () => {
 })
 
 describe('stepServings', () => {
-  it('steps by 0.5 in both directions', () => {
-    expect(stepServings(1, 1)).toBe(1.5)
-    expect(stepServings(1.5, -1)).toBe(1)
-    expect(stepServings(1.25, 1)).toBe(1.75)
+  it('steps by 0.25 in both directions', () => {
+    expect(stepServings(1, 1)).toBe(1.25)
+    expect(stepServings(1.25, -1)).toBe(1)
+    expect(stepServings(1.5, 1)).toBe(1.75)
   })
 
   it('clamps at the minimum servings', () => {
-    expect(stepServings(0.5, -1)).toBe(MIN_SERVINGS)
+    expect(stepServings(0.25, -1)).toBe(MIN_SERVINGS)
     expect(stepServings(MIN_SERVINGS, -1)).toBe(MIN_SERVINGS)
   })
 })

--- a/src/screens/FoodDetail/index.util.ts
+++ b/src/screens/FoodDetail/index.util.ts
@@ -27,7 +27,7 @@ export interface ServingFraction {
   value: number
 }
 
-export const SERVING_STEP = 0.5
+export const SERVING_STEP = 0.25
 
 export const MIN_SERVINGS = 0.25
 


### PR DESCRIPTION
## Summary
- Rename the HealthKit primer button from "Connect" to "Continue" to resolve the Guideline 5.1.1(iv) rejection (submission c723f691)
- Change the FoodDetail serving stepper to move by ¼ instead of ½, matching the fraction chips on screen
- Bump iOS build number to 28

## Test plan
- `npx jest src/screens/FoodDetail/__tests__/index.util.test.ts` — 23/23 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)