### PR TITLE
Build 29: goal weight target, tappable calorie ring, stepper and copy fixes

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.stateofhealh.tracker",
       "icon": "./assets/icon.png",
-      "buildNumber": "28",
+      "buildNumber": "29",
       "usesAppleSignIn": true,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -471,7 +471,7 @@ export const BURN_INFO_SHEET_SUBTITLE =
 export const BURN_INFO_LIFTS_TITLE = 'Lifts'
 
 export const BURN_INFO_LIFTS_BODY =
-  'Based on how long you lifted — or about 3.5 minutes per completed set when timing isn’t available — scaled to your body weight.'
+  'Today’s workout is based on your workout timer. Past workouts assume about 3.5 minutes per completed set. Both are scaled to your body weight.'
 
 export const BURN_INFO_STEPS_TITLE = 'Steps'
 
@@ -480,10 +480,10 @@ export const BURN_INFO_STEPS_BODY =
 
 export const BURN_INFO_RUNS_TITLE = 'Runs'
 
-export const BURN_INFO_RUNS_BODY = 'Estimated from each run’s distance — the same number you see on the Runs screen.'
+export const BURN_INFO_RUNS_BODY = 'Estimated from each run’s distance. This is the same number you see on the Runs screen.'
 
 export const BURN_INFO_DISCLAIMER =
-  'Body weight comes from your most recent weigh-in. These are estimates — actual burn varies with intensity and physiology.'
+  'Body weight comes from your most recent weigh-in. These are estimates, and actual burn varies with intensity and physiology.'
 
 export const ACTIVITY_CONNECT_HEALTH_TITLE = 'Connect Apple Health'
 
@@ -614,6 +614,8 @@ export const ACCOUNT_TOTAL_RUNS_LABEL = 'Total runs'
 export const ACCOUNT_TOTAL_WORKOUT_DAYS_LABEL = 'Total workout days'
 
 export const ACCOUNT_DAILY_STEPS_LABEL = 'Daily steps'
+
+export const ACCOUNT_GOAL_WEIGHT_LABEL = 'Goal weight'
 
 export const ACCOUNT_SETTINGS_SECTION_TITLE = 'Settings'
 

--- a/src/screens/Account/components/AccountListItem/index.tsx
+++ b/src/screens/Account/components/AccountListItem/index.tsx
@@ -4,6 +4,7 @@ import {TouchableOpacity} from 'react-native'
 
 import {Theme} from '@styles/theme'
 
+import GoalWeightModal from '@components/dialog/GoalWeightModal'
 import StepGoalModal from '@components/dialog/StepGoalModal'
 import TargetCaloriesModal from '@components/dialog/TargetCaloriesModal'
 import TargetWorkoutsModal from '@components/dialog/TargetWorkoutsModal'
@@ -18,7 +19,7 @@ interface Props {
   readonly value?: string
   readonly icon: React.JSX.Element
   readonly tileVariant?: IconTileVariant
-  readonly type: 'target-calories' | 'target-workouts' | 'step-goal' | 'auth' | 'info'
+  readonly type: 'target-calories' | 'target-workouts' | 'step-goal' | 'goal-weight' | 'auth' | 'info'
   readonly clickable?: boolean
   readonly danger?: boolean
   readonly isLastInGroup?: boolean
@@ -53,6 +54,8 @@ const AccountListItem = (props: Props) => {
         return <TargetWorkoutsModal {...dialogProps} />
       case 'step-goal':
         return <StepGoalModal {...dialogProps} />
+      case 'goal-weight':
+        return <GoalWeightModal {...dialogProps} />
       default:
         break
     }

--- a/src/screens/Account/index.tsx
+++ b/src/screens/Account/index.tsx
@@ -31,6 +31,7 @@ import {
   ACCOUNT_AUTH_SECTION_TITLE,
   ACCOUNT_DAILY_CALORIES_LABEL,
   ACCOUNT_DAILY_STEPS_LABEL,
+  ACCOUNT_GOAL_WEIGHT_LABEL,
   ACCOUNT_LOGGED_IN_AS_GUEST,
   GUEST_AVATAR_INITIAL,
   ACCOUNT_PRIVACY_POLICY,
@@ -43,7 +44,8 @@ import {
   ACCOUNT_TOTAL_WORKOUT_DAYS_LABEL,
   ACCOUNT_WEIGHT_UNIT_LABEL,
   ACCOUNT_WELCOME_TEXT,
-  ACCOUNT_WORKOUTS_PER_WEEK_LABEL
+  ACCOUNT_WORKOUTS_PER_WEEK_LABEL,
+  PROGRESS_BODY_SET_GOAL_LABEL
 } from '@constants/strings'
 import {urls} from '@constants/urls'
 
@@ -61,6 +63,7 @@ const AccountScreen = () => {
   const targetWorkouts = useUserData(state => state.targetWorkouts)
   const targetCalories = useUserData(state => state.targetCalories)
   const stepGoal = useUserData(state => state.stepGoal)
+  const goalWeight = useUserData(state => state.goalWeight)
   const weightUnitLabel = useWeightUnitLabel()
 
   const userEmail = useAuthStore(state => state.userEmail)
@@ -152,8 +155,16 @@ const AccountScreen = () => {
           label={ACCOUNT_DAILY_STEPS_LABEL}
           value={stepGoal.toLocaleString()}
           tileVariant="teal"
-          isLastInGroup={true}
           icon={<StepsIcon color={Theme.colors.teal} size={TILE_ICON_SIZE} />}
+        />
+
+        <AccountListItem
+          type="goal-weight"
+          label={ACCOUNT_GOAL_WEIGHT_LABEL}
+          value={goalWeight !== null ? `${goalWeight} ${weightUnitLabel}` : PROGRESS_BODY_SET_GOAL_LABEL}
+          tileVariant="teal"
+          isLastInGroup={true}
+          icon={<ScaleIcon color={Theme.colors.teal} size={TILE_ICON_SIZE} />}
         />
       </View>
     </>

--- a/src/screens/FoodDetail/__tests__/index.util.test.ts
+++ b/src/screens/FoodDetail/__tests__/index.util.test.ts
@@ -39,15 +39,34 @@ describe('formatServingsDisplay', () => {
 })
 
 describe('stepServings', () => {
-  it('steps by 0.25 in both directions', () => {
+  it('walks up through the fraction chip stops', () => {
     expect(stepServings(1, 1)).toBe(1.25)
+    expect(stepServings(1.25, 1)).toBe(1.33)
+    expect(stepServings(1.33, 1)).toBe(1.5)
+    expect(stepServings(1.5, 1)).toBe(1.66)
+    expect(stepServings(1.66, 1)).toBe(1.75)
+    expect(stepServings(1.75, 1)).toBe(2)
+  })
+
+  it('walks down through the fraction chip stops', () => {
+    expect(stepServings(2, -1)).toBe(1.75)
+    expect(stepServings(1.75, -1)).toBe(1.66)
+    expect(stepServings(1.66, -1)).toBe(1.5)
+    expect(stepServings(1.5, -1)).toBe(1.33)
+    expect(stepServings(1.33, -1)).toBe(1.25)
     expect(stepServings(1.25, -1)).toBe(1)
-    expect(stepServings(1.5, 1)).toBe(1.75)
+    expect(stepServings(1, -1)).toBe(0.75)
+  })
+
+  it('snaps off-ladder values to the nearest stop in the pressed direction', () => {
+    expect(stepServings(1.2, 1)).toBe(1.25)
+    expect(stepServings(1.2, -1)).toBe(1)
   })
 
   it('clamps at the minimum servings', () => {
     expect(stepServings(0.25, -1)).toBe(MIN_SERVINGS)
     expect(stepServings(MIN_SERVINGS, -1)).toBe(MIN_SERVINGS)
+    expect(stepServings(0.33, -1)).toBe(0.25)
   })
 })
 

--- a/src/screens/FoodDetail/index.util.ts
+++ b/src/screens/FoodDetail/index.util.ts
@@ -27,8 +27,6 @@ export interface ServingFraction {
   value: number
 }
 
-export const SERVING_STEP = 0.25
-
 export const MIN_SERVINGS = 0.25
 
 export const SERVING_FRACTIONS: ServingFraction[] = [
@@ -72,8 +70,24 @@ export const formatServingsDisplay = (servings: number): string => {
   return whole === 0 ? glyph : `${whole}${glyph}`
 }
 
-export const stepServings = (servings: number, direction: 1 | -1): number =>
-  Math.max(MIN_SERVINGS, roundServings(servings + direction * SERVING_STEP))
+// Each whole number splits into the same stops as the fraction chips:
+// 1 -> 1¼ -> 1⅓ -> 1½ -> 1⅔ -> 1¾ -> 2
+const STEP_FRACTIONS = [0, ...SERVING_FRACTIONS.map(f => f.value)]
+
+export const stepServings = (servings: number, direction: 1 | -1): number => {
+  const whole = Math.floor(servings)
+  const fraction = getFractionalPart(servings)
+
+  if (direction === 1) {
+    const next = STEP_FRACTIONS.find(f => f > fraction + FRACTION_EPSILON)
+    return roundServings(next === undefined ? whole + 1 : whole + next)
+  }
+
+  const prev = [...STEP_FRACTIONS].reverse().find(f => f < fraction - FRACTION_EPSILON)
+  const stepped = prev === undefined ? whole - 1 + 0.75 : whole + prev
+
+  return Math.max(MIN_SERVINGS, roundServings(stepped))
+}
 
 // Replaces only the fractional part, keeping the whole part: 1.5 + ¼ -> 1.25
 export const applyFractionPart = (servings: number, fraction: number): number =>

--- a/src/screens/Macros/components/DailySummaryCard/index.tsx
+++ b/src/screens/Macros/components/DailySummaryCard/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react'
+import React, {useState} from 'react'
 
-import {View} from 'react-native'
+import {TouchableOpacity, View} from 'react-native'
 
 import {MacroTotals} from '@data/models/Macros'
 import {Theme} from '@styles/theme'
 import Svg, {Circle} from 'react-native-svg'
 
+import TargetCaloriesModal from '@components/dialog/TargetCaloriesModal'
 import MacroGramRow from '@components/MacroGramRow'
 import Text from '@components/Text'
 
@@ -23,6 +24,8 @@ interface Props {
 }
 
 const DailySummaryCard = ({totals, targets}: Props) => {
+  const [isTargetModalVisible, setIsTargetModalVisible] = useState(false)
+
   const radius = (RING_SIZE - RING_STROKE_WIDTH) / 2
   const circumference = 2 * Math.PI * radius
   const fraction = progressFraction(totals.calories, targets.calories)
@@ -57,13 +60,16 @@ const DailySummaryCard = ({totals, targets}: Props) => {
           )}
         </Svg>
 
-        <View style={styles.ringCenter}>
+        <TouchableOpacity
+          style={styles.ringCenter}
+          activeOpacity={0.6}
+          onPress={() => setIsTargetModalVisible(true)}>
           <Text style={styles.balanceValue}>{formatCalories(balance.amount)}</Text>
 
           <Text style={[styles.balanceLabel, balance.isOver && styles.balanceLabelOver]}>
             {balance.isOver ? OVER_TEXT : REMAINING_TEXT}
           </Text>
-        </View>
+        </TouchableOpacity>
       </View>
 
       <View style={styles.macroRows}>
@@ -73,6 +79,8 @@ const DailySummaryCard = ({totals, targets}: Props) => {
 
         <MacroGramRow label={FAT_LABEL} grams={totals.fat} dotColor={Theme.colors.lime} isLast />
       </View>
+
+      <TargetCaloriesModal isVisible={isTargetModalVisible} onDismissed={() => setIsTargetModalVisible(false)} />
     </View>
   )
 }


### PR DESCRIPTION
## Summary
- Serving stepper on FoodDetail walks the actual fraction chip stops (¼ → ⅓ → ½ → ⅔ → ¾ → next whole) instead of a fixed increment
- Tapping the calorie ring center on the Macros screen opens the daily target calories dialog
- New Goal weight row in the Account Targets section, wired to the same GoalWeightModal as the Body tab
- Calorie burn bottom sheet: clarified the Lifts explanation (today uses the workout timer, past days assume ~3.5 min/set) and removed em dashes
- Bump iOS build number to 29

## Test plan
- `npx jest src/screens` — 285/285 passing, tsc clean
- New unit tests cover the fraction-ladder stepper walk, snapping, and clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)